### PR TITLE
Correct Repolinter error

### DIFF
--- a/app/src/main/java/com/skyhook/locationquickstart/MainActivity.java
+++ b/app/src/main/java/com/skyhook/locationquickstart/MainActivity.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * SPDX-License-Identifier: CC-BY-4.0
+ */
+
 package com.skyhook.locationquickstart;
 
 import android.Manifest;


### PR DESCRIPTION
Hi @quic-sgalat  

Our team has enabled the QuIC Repolinter GitHub Action on github.com/quic repos. Repolinter is a linting tool we use to ensure open source best practices e.g. LICENSE information is present.  This PR corrects the one issue that was identified. 

Did we author the file in question? I added the quic copyright and the relevant license information but LMK if any concerns.

Thanks,
Mark